### PR TITLE
refactor: Save the CLA signatures in a Freshli repository

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'CLA/signatures/v1.0/cla.json'
-          path-to-document: 'https://github.com/corgibytes/freshli-cli/blob/main/CLA/CLA-v1.0.md'
+          path-to-document: 'https://github.com/corgibytes/freshli/blob/main/CLA/CLA-v1.0.md'
           branch: 'main'
           allowlist: dependabot[bot]
 


### PR DESCRIPTION
A part of branch protection is to disable direct commits on the main branch
Therefore if we want to save the signatures some place we need a separate repository without the main branch protected.