### PR TITLE
Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "[Setup] - Install Ruby"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1 # Not needed with a .ruby-version file
+          ruby-version: 3.0 # Not needed with a .ruby-version file
           bundler-cache: true
 
       - name: "[Setup] - Install CycloneDX CLI"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java-version: [ '8', '11', '17' ]
+
+    runs-on: ${{ matrix.os }}
     env:
       BUILD_ARTIFACTS_FOLDER: build_artifacts
 
@@ -23,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: ${{ matrix.java-version }}
 
       - name: "[Setup] - Install Ruby"
         uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ replay_pid*
 .gradle
 **/build/
 !src/**/build/
-exe
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     cucumber-tag-expressions (4.1.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-mingw32)
     json (2.6.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -67,6 +69,8 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     sqlite3 (1.5.3-arm64-darwin)
+    sqlite3 (1.5.3-x64-mingw-ucrt)
+    sqlite3 (1.5.3-x64-mingw32)
     sqlite3 (1.5.3-x86_64-linux)
     sys-uname (1.2.2)
       ffi (~> 1.1)
@@ -75,6 +79,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x64-mingw-ucrt
+  x64-mingw32
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -18,8 +18,17 @@ docker build -t freshli-agent-java .
 
 Assuming you have a recent version of Ruby installed, and you're able to install RubyGems with being logged in as root, then you can use the `bin/build.rb` script to build the application.
 
+> :warning: **Note for Windows Users**
+> Ruby version 3.1 might not work, because of compatibility issues with one of the libraries that is used by the Cucumber/Aruba testing tool. All Ruby 3.0 versions are suspected to work. Testing has been done with the version of ruby that can be installed via `winget install RubyInstallerTeam.RubyWithDevKit.3.0`. Please create an issue if you see errors when running the build or the tests using the scripts in the `bin` directory or when running `bundle exec cucumber`.
+
+On macOS or Linux:
 ```bash
 bin/build.rb
+```
+
+On Windows:
+```pwsh
+ruby .\bin\build.rb
 ```
 
 #### Using Gradle
@@ -28,11 +37,17 @@ Make sure you have JDK version 17 or later installed and have your `JAVA_HOME` e
 
 Run the following command to create a complete deployable distribution for the project.
 
+On macOS or Linux:
 ```bash
-./gradle installDist
+./gradlew installDist
 ```
 
-This will create `build/install/freshli-agent-java`. Inside the `bin` directory contain within are wrappers for running the application.
+On Windows:
+```pwsh
+.\gradlew.bat installDist
+```
+
+This will create `build/install/freshli-agent-java`. Within that folder, the `bin` directory contains wrappers for running the application. Adding the full path to that `bin` directory to the `PATH` environment variable will enable you to run `freshli-agent-java` from any directory.
 
 ## Running
 
@@ -50,42 +65,62 @@ docker run freshli-agent-java --help
 
 It's possible to instruct Gradle to run the command for you.
 
+On macOS and Linux:
 ```bash
 ./gradle run --args="--help"
+```
+
+On Windows:
+```pwsh
+`.\gradlew.bat run --args="--help"
 ```
 
 #### Running from Distribution Directory
 
 You can run the program from the distribution that's created by the `installDist` Gradle task.
 
+On macOS and Linux:
 ```bash
-./build/install/freshli-agent-java/bin/freshli-agent-java --help
+./build/install/freshli-agent-java/bin/freshli-agent-java.bat --help
 ```
 
-#### Using symbolic link in `exe` directory
-
-`./gradlew installDist` (which is also run by `bin/build.rb`) creates a symbolic link in the `exe` directory to assist with running the application. The symbolic link points to the directory in the distribution directory as described above.
-
-```bash
-exe/freshli-agent-java --help
+On Windows:
+```pwsh
+.\build\install\freshli-agent-java\bin\freshli-agent-java --help
 ```
 
 ### Running Tests
 
+#### Dependencies
+
+The [`cyclonedx` CLI](https://github.com/CycloneDX/cyclonedx-cli) command needs to be in your `PATH` for the tests to pass. You'll need to [download](https://github.com/CycloneDX/cyclonedx-cli/releases) the version of the command that matches your platform, and rename it to `cyclonedx` before placing its directory in the `PATH` environment variable. 
+
 #### Using `bin/test.rb`
 
-You can run both the application's unit tests that are written in Kotlin and the application's acceptance tests that are written using Cucumber and Aruba by running:
+You can run both the application's unit and integration tests that are written in Kotlin and the application's acceptance tests that are written using Cucumber and Aruba by running:
 
+On macOS and Linux:
 ```bash
 bin/test.rb
+```
+
+On Windows:
+```pwsh
+ruby .\bin\test.rb
 ```
 
 #### Running Directly
 
 The application's unit tests can be run with:
 
+On macOS and Linux:
 ```bash
 ./gradlew test
+```
+
+On Windows:
+```pwsh
+.\gradlew.bat test
 ```
 
 And the application's acceptance tests can be run with:

--- a/bin/format.rb
+++ b/bin/format.rb
@@ -3,7 +3,7 @@
 
 require_relative './support/execute'
 
-status = execute('bundle check > /dev/null')
+status = execute("bundle check > #{null_output_target}")
 status = execute('bundle install') unless status.success?
 
 rubocop_status = execute('bundle exec rubocop --autocorrect --color') if status.success?

--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -40,7 +40,7 @@ end
 linter_failed = false
 
 if perform_rubocop
-  status = execute('bundle check > /dev/null')
+  status = execute("bundle check > #{null_output_target}")
   status = execute('bundle install') unless status.success?
 
   status = execute('bundle exec rubocop --color') if status.success?

--- a/bin/support/execute.rb
+++ b/bin/support/execute.rb
@@ -84,3 +84,7 @@ def execute(command)
   end
   exit_status
 end
+
+def null_output_target
+  Gem.win_platform? ? 'NUL:' : '/dev/null'
+end

--- a/bin/test.rb
+++ b/bin/test.rb
@@ -42,7 +42,7 @@ end
 status = execute("ruby #{File.dirname(__FILE__)}/build.rb") if perform_build
 
 if status.nil? || status.success?
-  status = execute('bundle check > /dev/null')
+  status = execute("bundle check > #{null_output_target}")
   status = execute('bundle install') unless status.success?
 
   status = execute('./gradlew test') if status.success?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,14 +34,3 @@ tasks.withType<KotlinCompile> {
 application {
     mainClass.set("com.corgibytes.freshli.agent.java.MainKt")
 }
-
-tasks.register<Exec>("publishExe") {
-    commandLine("bash", "-c", "mkdir -p exe && ln -sF ../build/install/freshli-agent-java/bin/freshli-agent-java exe/freshli-agent-java")
-}
-tasks.named("installDist") { finalizedBy("publishExe") }
-
-tasks.register<Delete>("cleanExe") {
-    isFollowSymlinks = false
-    delete("exe")
-}
-tasks.named("clean") { finalizedBy("cleanExe") }

--- a/features/detect-manifests.feature
+++ b/features/detect-manifests.feature
@@ -16,7 +16,7 @@ Feature: `detect-manifests` command
 
     Given I clone the git repository "https://github.com/questdb/questdb" with the sha "0b465538639e24850e3471bdb0a234c20d8af58b"
     When I run `freshli-agent-java detect-manifests tmp/repositories/questdb`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     pom.xml
     """
@@ -28,7 +28,7 @@ Feature: `detect-manifests` command
 
     Given I clone the git repository "https://github.com/protocolbuffers/protobuf" with the sha "d8421bd49c1328dc5bcaea2e60dd6577ac235336"
     When I run `freshli-agent-java detect-manifests tmp/repositories/protobuf`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     java/pom.xml
     java/protoc/pom.xml
@@ -42,7 +42,7 @@ Feature: `detect-manifests` command
 
     Given I clone the git repository "https://github.com/serverless/serverless" with the sha "9c2ebb78d8db30acde24bd31efa1d6516d177b0e"
     When I run `freshli-agent-java detect-manifests tmp/repositories/serverless`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     docs/providers/openwhisk/examples/hello-world/java/pom.xml
     lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml

--- a/features/process-manifest.feature
+++ b/features/process-manifest.feature
@@ -12,7 +12,7 @@ Feature: `process-manifest` command
 
     Given I clone the git repository "https://github.com/corgibytes/freshli-fixture-java-maven-version-range" with the sha "2260b7cc3b7ae2b0ff80c818a8ec70ae82cd14ec"
     When I run `freshli-agent-java process-manifest tmp/repositories/freshli-fixture-java-maven-version-range/pom.xml 2021-01-01T00:00:00Z`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     tmp/repositories/freshli-fixture-java-maven-version-range/target/bom.json
     """
@@ -27,7 +27,7 @@ Feature: `process-manifest` command
 
     Given I clone the git repository "https://github.com/questdb/questdb" with the sha "0b465538639e24850e3471bdb0a234c20d8af58b"
     When I run `freshli-agent-java process-manifest tmp/repositories/questdb/pom.xml 2022-08-23T19:45:55Z`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     tmp/repositories/questdb/target/bom.json
     """
@@ -40,7 +40,7 @@ Feature: `process-manifest` command
   Scenario: A multi-module project located in a sub-directory
     Given I clone the git repository "https://github.com/protocolbuffers/protobuf" with the sha "d8421bd49c1328dc5bcaea2e60dd6577ac235336"
     When I run `freshli-agent-java process-manifest tmp/repositories/protobuf/java/pom.xml 2022-08-23T19:45:55Z`
-    Then it should pass with exactly:
+    Then it should pass with exact output containing file paths:
     """
     tmp/repositories/protobuf/java/target/bom.json
     """

--- a/features/step_definitions/command.rb
+++ b/features/step_definitions/command.rb
@@ -1,0 +1,12 @@
+# this block is based on https://github.com/cucumber/aruba/blob/v2.1.0/lib/aruba/cucumber/command.rb#L404..L414
+Then(/^it should (pass|fail) with exact output containing file paths:$/) do |pass_fail, expected|
+  last_command_started.stop
+
+  if pass_fail == "pass"
+    expect(last_command_stopped).to be_successfully_executed
+  else
+    expect(last_command_stopped).not_to be_successfully_executed
+  end
+
+  expect(last_command_stopped).to have_output an_output_string_being_eq(Platform.normalize_file_separators(expected))
+end

--- a/features/step_definitions/cyclonedx.rb
+++ b/features/step_definitions/cyclonedx.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 Then('the CycloneDX file {string} should be valid') do |bom_path|
-  unless system("cyclonedx validate --fail-on-errors --input-file #{Aruba.config.working_directory}/#{bom_path}",
-                out: '/dev/null', err: '/dev/null')
+  full_bom_path = Platform.normalize_file_separators("#{Aruba.config.working_directory}/#{bom_path}")
+  unless system("cyclonedx validate --fail-on-errors --input-file #{full_bom_path}",
+                out: Platform.null_output_target, err: Platform.null_output_target)
     raise "CycloneDX file is not valid: #{bom_path}"
   end
 end
 
 Then('the CycloneDX file {string} should contain {string}') do |bom_path, package_url|
-  bom_file_lines = File.readlines("#{Aruba.config.working_directory}/#{bom_path}")
+  full_bom_path = Platform.normalize_file_separators("#{Aruba.config.working_directory}/#{bom_path}")
+  bom_file_lines = File.readlines(full_bom_path)
   was_package_url_found = false
   bom_file_lines.each do |line|
     if line.include?(package_url)

--- a/features/step_definitions/git.rb
+++ b/features/step_definitions/git.rb
@@ -10,23 +10,23 @@ Given('I clone the git repository {string} with the sha {string}') do |repositor
 
   unless Dir.exist?(cloned_dir)
     $stdout.print "Cloning #{repository_url} ..."
-    unless system("git clone #{repository_url}", chdir: repositories_dir, out: '/dev/null', err: '/dev/null')
+    unless system("git clone #{repository_url}", chdir: repositories_dir, out: Platform.null_output_target, err: Platform.null_output_target)
       raise "Failed to clone #{repository_url}"
     end
 
     puts 'done.'
   end
-  unless system("git checkout #{sha}", chdir: cloned_dir, out: '/dev/null', err: '/dev/null')
+  unless system("git checkout #{sha}", chdir: cloned_dir, out: Platform.null_output_target, err: Platform.null_output_target)
     raise "Failed to checkout #{sha}"
   end
 end
 
 Then('running git status should not report any modifications for {string}') do |git_repository_path|
   git_repository_path_in_working_directory = "#{Aruba.config.working_directory}/#{git_repository_path}"
-  system('git update-index --refresh', chdir: git_repository_path_in_working_directory, out: '/dev/null',
-                                       err: '/dev/null')
-  unless system('git diff-index --quiet HEAD --', chdir: git_repository_path_in_working_directory, out: '/dev/null',
-                                                  err: '/dev/null')
+  system('git update-index --refresh', chdir: git_repository_path_in_working_directory, out: Platform.null_output_target,
+                                       err: Platform.null_output_target)
+  unless system('git diff-index --quiet HEAD --', chdir: git_repository_path_in_working_directory, out: Platform.null_output_target,
+                                                  err: Platform.null_output_target)
     raise "The working directory is not clean: #{git_repository_path}"
   end
 end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -7,6 +7,9 @@ Aruba.configure do |config|
   config.exit_timeout = 300
   # Use aruba working directory
   config.home_directory = File.join(config.root_directory, config.working_directory)
+  # include the `freshli-agent-java` run scripts from the build directory in the path
+  config.command_search_paths << File.expand_path('../../../build/install/freshli-agent-java/bin', __FILE__)
+end
 
 module Platform
   def self.null_output_target

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rubygems'
 require 'aruba/cucumber'
 
 Aruba.configure do |config|
@@ -14,5 +15,10 @@ end
 module Platform
   def self.null_output_target
     Gem.win_platform? ? 'NUL:' : '/dev/null'
+  end
+
+  def self.normalize_file_separators(value)
+    separator = File::ALT_SEPARATOR || File::SEPARATOR
+    value.gsub('/', separator)
   end
 end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -7,4 +7,9 @@ Aruba.configure do |config|
   config.exit_timeout = 300
   # Use aruba working directory
   config.home_directory = File.join(config.root_directory, config.working_directory)
+
+module Platform
+  def self.null_output_target
+    Gem.win_platform? ? 'NUL:' : '/dev/null'
+  end
 end

--- a/src/main/kotlin/com/corgibytes/freshli/agent/java/Main.kt
+++ b/src/main/kotlin/com/corgibytes/freshli/agent/java/Main.kt
@@ -139,7 +139,7 @@ class ProcessManifest: CliktCommand(help="Processes manifest files in the specif
 
     private suspend fun generateBillOfMaterials(manifestDirectory: Path) {
         val result = process(
-            "mvn",
+            SystemUtils.mavenCommand,
             "org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom",
             "-DincludeLicenseText=true",
             "-DincludeTestScope=true",
@@ -160,7 +160,7 @@ class ProcessManifest: CliktCommand(help="Processes manifest files in the specif
 
     private suspend fun resolveVersionRanges(manifestDirectory: Path) {
         val result = process(
-            "mvn",
+            SystemUtils.mavenCommand,
             "com.corgibytes:versions-maven-plugin:resolve-ranges-historical",
             "-DversionsAsOf=$asOfDate",
 

--- a/src/main/kotlin/com/corgibytes/freshli/agent/java/Main.kt
+++ b/src/main/kotlin/com/corgibytes/freshli/agent/java/Main.kt
@@ -80,8 +80,9 @@ class DetectManifests: CliktCommand(help="Detects manifest files in the specifie
     private val path by argument()
 
     override fun run() {
+        val normalizedPath = SystemUtils.normalizeFileSeparators(path)
         val submodules = mutableListOf<String>()
-        val directory = File(path)
+        val directory = File(normalizedPath)
         val results = directory.walkTopDown().filter { it.name == "pom.xml" }.map { it.path }.toMutableList()
 
         val mavenReader = MavenXpp3Reader()
@@ -94,7 +95,7 @@ class DetectManifests: CliktCommand(help="Detects manifest files in the specifie
 
         results.removeIf { submodules.contains(it) }
 
-        results.map{ it.removePrefix("$path/") }.sorted().forEach {
+        results.map{ it.removePrefix("$normalizedPath" + File.separator) }.sorted().forEach {
             println(it)
         }
     }
@@ -105,7 +106,7 @@ class ProcessManifest: CliktCommand(help="Processes manifest files in the specif
     private val asOfDate by argument(name="AS_OF_DATE")
 
     override fun run() {
-        val manifestFile = File(manifestLocation)
+        val manifestFile = File(SystemUtils.normalizeFileSeparators(manifestLocation))
 
         if (!manifestFile.exists()) {
             println("Unable to access $manifestLocation")

--- a/src/main/kotlin/com/corgibytes/freshli/agent/java/SystemUtils.kt
+++ b/src/main/kotlin/com/corgibytes/freshli/agent/java/SystemUtils.kt
@@ -12,5 +12,9 @@ class SystemUtils {
                 }
                 return "mvn"
             }
+
+        fun normalizeFileSeparators(value: String): String {
+            return value.replace("/", File.separator)
+        }
     }
 }

--- a/src/main/kotlin/com/corgibytes/freshli/agent/java/SystemUtils.kt
+++ b/src/main/kotlin/com/corgibytes/freshli/agent/java/SystemUtils.kt
@@ -1,0 +1,16 @@
+package com.corgibytes.freshli.agent.java
+
+import java.io.File
+
+class SystemUtils {
+    companion object {
+        val mavenCommand: String
+            get() {
+                val osName = System.getProperty("os.name").lowercase()
+                if (osName.contains("win")) {
+                    return "mvn.cmd"
+                }
+                return "mvn"
+            }
+    }
+}


### PR DESCRIPTION
Note, tests will fail to run on Ruby 3.1. A detailed description can be found in the commit message for commit 3df7699cc8b026123b53f3f54cfcd00e18a1a5b5.

* Fixes path handling
* Fixes null output redirection handling
* Fixes executable file name to use when running Maven
* Enables running builds on Windows in CI
* Enables running builds on Java LTS versions (8, 11, and 17) in CI
* Updates `README.md` to include Windows specific instructions.

Fixes #53.